### PR TITLE
Fix short address decoding

### DIFF
--- a/RLP.sol
+++ b/RLP.sol
@@ -291,14 +291,10 @@ library RLP {
  /// @param self The RLPItem.
  /// @return The decoded string.
  function toAddress(RLPItem memory self) internal constant returns (address data) {
-     if(!isData(self))
+     var (, len) = _decode(self);
+     if (len > 20)
          throw;
-     var (rStartPos, len) = _decode(self);
-     if (len != 20)
-         throw;
-     assembly {
-         data := div(mload(rStartPos), exp(256, 12))
-     }
+     return address(toUint(self));
  }
 
  // Get the payload offset.


### PR DESCRIPTION
Example addresses:
```
0x0014F55A50b281EFD12294f0Cda821Bd8171e920
0x0000000000000000000000000000000000000000
```